### PR TITLE
The input message does not violate any of the rules.

### DIFF
--- a/src/main/java/org/wwj/cdc/MysqlCdc.java
+++ b/src/main/java/org/wwj/cdc/MysqlCdc.java
@@ -60,7 +60,7 @@ public class MysqlCdc implements ApplicationRunner, Serializable {
         // 配置数据源，设置并行度
         DataStreamSource<String> streamSource = env
                 .fromSource(sourceBuilder.build(), WatermarkStrategy.noWatermarks(), "mysql-cdc-source")
-                .setParallelism(1);
+                .setParallelism(4);
         streamSource.print();
         try {
             env.execute();


### PR DESCRIPTION
Output:
Update Flink CDC parallelism to 4

This change updates the Flink CDC source parallelism from 1 to 4 in MysqlCdc.java.